### PR TITLE
Remove gem test include from lib

### DIFF
--- a/lib/declarative_minitest.rb
+++ b/lib/declarative_minitest.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'declarative_minitest/test'
-
 #:nodoc:
 module DeclarativeMinitest
 end


### PR DESCRIPTION
<img width="885" alt="image" src="https://user-images.githubusercontent.com/1909544/172412952-df0c1304-32b8-40c9-b9e1-b76a01994337.png">

This file doesn't actually exist as far as I can tell so it will always raise. I caught this while trying to get https://github.com/Shopify/tapioca to work with an app using this gem. 